### PR TITLE
修复libQt5Core.so.5库缺失bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,23 @@ cd qbittorrent
 #构建docker镜像
 docker build -t qbittorrent:latest .
 ```
-
+## 自行运行
+```bash
+docker run -d \
+  --name=qbittorrent \
+  -p 7881:7881 \
+  -p 7881:7881/udp \
+  -p 18080:18080 \
+  -v /data/qbittorrent/config:/etc/qBittorrent \
+  -v /data/qbittorrent/downloads:/downloads \
+  --restart unless-stopped \
+  qbittorrent:latest
+```
 
 
 ## 运行
 
 不想自行构建的，可通过xiaoz构建好的镜像直接运行：
-
 ```bash
 docker run -d \
   --name=qbittorrent \

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ docker run -d \
 
 ## 运行
 
-不想自行构建的，可通过xiaoz构建好的镜像直接运行：
+不想自行构建的，可通过comdotwww构建好的镜像直接运行：
 ```bash
 docker run -d \
   --name=qbittorrent \
@@ -70,7 +70,7 @@ docker run -d \
 
 
 
-## 联系我
+## 源作者联系方式
 
 * Blog：https://www.xiaoz.me/
 * QQ：337003006

--- a/README.md
+++ b/README.md
@@ -16,23 +16,13 @@ cd qbittorrent
 #构建docker镜像
 docker build -t qbittorrent:latest .
 ```
-## 自行运行
-```bash
-docker run -d \
-  --name=qbittorrent \
-  -p 7881:7881 \
-  -p 7881:7881/udp \
-  -p 18080:18080 \
-  -v /data/qbittorrent/config:/etc/qBittorrent \
-  -v /data/qbittorrent/downloads:/downloads \
-  --restart unless-stopped \
-  qbittorrent:latest
-```
+
 
 
 ## 运行
 
 不想自行构建的，可通过xiaoz构建好的镜像直接运行：
+
 ```bash
 docker run -d \
   --name=qbittorrent \

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ qBittorrent是一个跨平台的自由BitTorrent客户端，其图形用户界�
 
 ```bash
 #克隆此项目
-git clone https://github.com/helloxz/qbittorrent.git
+git clone https://github.com/comdotwww/qbittorrent.git
 #进入项目
 cd qbittorrent
 #构建docker镜像
@@ -32,7 +32,7 @@ docker run -d \
   -v /data/qbittorrent/config:/etc/qBittorrent \
   -v /data/qbittorrent/downloads:/downloads \
   --restart unless-stopped \
-  helloz/qbittorrent
+  comdotwww/qbittorrent:latest
 ```
 
 * `7881`：用于传入连接的端口，TCP/UDP都需要映射，且主机端口和容器端口必须一致，否则无法下载和上传

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ docker run -d \
 
 ## 运行
 
-不想自行构建的，可通过comdotwww构建好的镜像直接运行：
+不想自行构建的，可通过xiaoz构建好的镜像直接运行：
 ```bash
 docker run -d \
   --name=qbittorrent \
@@ -70,7 +70,7 @@ docker run -d \
 
 
 
-## 源作者联系方式
+## 联系我
 
 * Blog：https://www.xiaoz.me/
 * QQ：337003006

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ qBittorrent是一个跨平台的自由BitTorrent客户端，其图形用户界�
 
 ```bash
 #克隆此项目
-git clone https://github.com/comdotwww/qbittorrent.git
+git clone https://github.com/helloxz/qbittorrent.git
 #进入项目
 cd qbittorrent
 #构建docker镜像
@@ -32,7 +32,7 @@ docker run -d \
   -v /data/qbittorrent/config:/etc/qBittorrent \
   -v /data/qbittorrent/downloads:/downloads \
   --restart unless-stopped \
-  comdotwww/qbittorrent:latest
+  helloz/qbittorrent
 ```
 
 * `7881`：用于传入连接的端口，TCP/UDP都需要映射，且主机端口和容器端口必须一致，否则无法下载和上传

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,8 @@
 #####	update:2021/03/19
 
 apt-get update
-apt install -y qbittorrent-nox curl binutils
+apt install -y qbittorrent-nox curl
+apt install -y binutils
 rm -rf /var/lib/apt/lists/*
 #创建存储配置目录
 mkdir -p /etc/qBittorrent
@@ -14,5 +15,7 @@ mkdir -p /etc/qBittorrent/data/GeoIP
 mkdir -p /downloads
 #下载GeoIP数据库
 curl -kLo /root/GeoLite2-Country.mmdb https://github.com/helloxz/qbittorrent/raw/main/GeoLite2-Country.mmdb
+
+strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
 
 chmod +x /usr/sbin/run.sh

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #####	update:2021/03/19
 
 apt-get update
-apt install -y qbittorrent-nox curl
+apt install -y qbittorrent-nox curl binutils
 rm -rf /var/lib/apt/lists/*
 #创建存储配置目录
 mkdir -p /etc/qBittorrent


### PR DESCRIPTION
```bash
qbittorrent-nox: error while loading shared libraries: libQt5Core.so.5: cannot open shared object file: No such fi                                                                                                            le or directory
```
## 解决libQt5Core.so.5库缺失问题

![image](https://user-images.githubusercontent.com/62149924/177047513-90678f0c-3e44-47e5-b484-395cf2bbcb09.png)
